### PR TITLE
Fix potential out-of-bounds read

### DIFF
--- a/sivec.rs
+++ b/sivec.rs
@@ -95,7 +95,17 @@ impl <T> SIVec<T> {
             panic!("SIVec: index bounds");
         }
         let store = self.vec.as_ptr() as *mut usize;
-        let ip = unsafe{store.offset(index as isize)};
+        let ip = unsafe {
+            let (base, amount) = if index > std::isize::MAX as usize {
+                let remaining = (index - std::isize::MAX as usize) as isize;
+                (store.offset(std::isize::MAX), remaining)
+            } else {
+                (store, index as isize)
+            };
+
+            base.offset(amount)
+        };
+
         // XXX Need to do an unsafe read because
         // all we have is a raw pointer.
         let si = unsafe{*ip};


### PR DESCRIPTION

Hi,

I came accross [your comment on reddit](https://www.reddit.com/r/rust/comments/8nwr87/tricking_the_hashmap/dzzdfld), and wanted to check out your indexing implementation. I think I found a potential buffer overflow/out of bounds read in the `get_mut_ref` function.

You validate that `index` is within the bounds of the buffer, which is fine, but then you cast `index` to an `isize` and use it as an offset:

https://github.com/BartMassey/sivec/blob/6e3ec2afc18567a928a4fed89368a307bd4885b6/sivec.rs#L98

I am not really sure if Rust guarantees two's complement representation, but at least on my system it uses it, so I figured I should tell you that this could lead to a negative offset (and thus reading out of bounds) if `index` is greater than `std::isize::MAX`.

Feel free to ignore if you dont care about this edge case, or if you feel the solution is inadequate (the new `ip` calculation feels kind of complex)